### PR TITLE
Added support for paths delimited by "

### DIFF
--- a/CppFixItAddIn/DTE2Utils.cs
+++ b/CppFixItAddIn/DTE2Utils.cs
@@ -294,6 +294,7 @@ namespace CppFixItAddIn
             }
             
             ts.TraceInformation("GetIncludesForProject: \n" + includes.ToString());
+
             return includes.ToString();
         }
 
@@ -366,7 +367,7 @@ namespace CppFixItAddIn
         static private string BuildIncludes(string rawIncludes, string includeType)
         {
             StringBuilder includes = new StringBuilder();
-            String cIncDir = rawIncludes.Replace(",", ";");
+            String cIncDir = rawIncludes.Replace("\"", "").Replace(",", ";");
             String[] cIncDirs = cIncDir.Split(';');
 
             var uniqueDirs = new HashSet<String>();


### PR DESCRIPTION
In my build/project setup, some include and library paths are delimited by "". While being obsolete, this seems to be allowed. In my case, the issue results from some automatic generation of the project files which I cannot influence. Thus, just removing the " seems to be most appropriate.
